### PR TITLE
refactor: make RequestService write-only (CQRS alignment)

### DIFF
--- a/backend/gateway/src/controllers/request.controller.ts
+++ b/backend/gateway/src/controllers/request.controller.ts
@@ -1,4 +1,8 @@
 import { requestServiceAWSLambda } from '../services/impl/RequestServiceImplAWSLambda.js';
+import { getAllRequestsFromDB } from '../utils/request.read.repository.ts';
+import { getRequestByIdFromDB } from '../utils/request.read.repository.ts';
+
+
 import { RequestService } from '../services/RequestService.js';
 import { Request, Response, NextFunction } from 'express';
 import { TicketRequestStatus, CreateRequestInput, UpdateRequestInput } from '../types/ticketRequest.js';
@@ -18,13 +22,7 @@ class RequestController {
                 status = statusParam as TicketRequestStatus;
             }
 
-            const result = await this.service.getAllRequests(status);
-
-            if (req.user?.role === 'USER') {
-                const filteredResult = result.filter((r: any) => r.userId === req.user?.userId);
-                return res.json(filteredResult);
-            }
-
+            const result = await getAllRequestsFromDB(status, req.user);
             res.json(result);
         } catch (error) {
             next(error);
@@ -34,13 +32,17 @@ class RequestController {
     getRequestById = async (req: Request, res: Response, next: NextFunction) => {
         try {
             const { id } = req.params;
-            const result = await this.service.getRequestById(id);
+
+            const result = await getRequestByIdFromDB(id);
 
             if (!result) {
                 return res.status(404).json({ error: 'Request not found' });
             }
 
-            if (req.user?.role === 'USER' && (result as any).userId !== req.user.userId) {
+            if (
+                req.user?.role === 'USER' &&
+                (result as any).userId !== req.user.userId
+            ) {
                 return res.status(403).json({ error: 'Access denied - not your request' });
             }
 
@@ -48,7 +50,8 @@ class RequestController {
         } catch (error) {
             next(error);
         }
-    }
+    };
+
 
     createRequest = async (req: Request, res: Response, next: NextFunction) => {
         try {

--- a/backend/gateway/src/services/RequestService.ts
+++ b/backend/gateway/src/services/RequestService.ts
@@ -1,10 +1,8 @@
-//TODO
+//interface for WRITE operations only, READ operations bypass it
 
 import { TicketRequest, TicketRequestStatus, CreateRequestInput, UpdateRequestInput } from '../types/ticketRequest.js';
 
 export interface RequestService {
-    getAllRequests: (status?: TicketRequestStatus) => Promise<TicketRequest[]>;
-    getRequestById: (requestId: string) => Promise<TicketRequest>;
-    createRequest: (input: CreateRequestInput) => Promise<TicketRequest>;
-    updateRequest: (input: UpdateRequestInput) => Promise<Partial<TicketRequest>>;
+    createRequest(input: CreateRequestInput): Promise<TicketRequest>;
+    updateRequest(input: UpdateRequestInput): Promise<Partial<TicketRequest>>;
 }

--- a/backend/gateway/src/services/impl/RequestServiceImplAWSLambda.ts
+++ b/backend/gateway/src/services/impl/RequestServiceImplAWSLambda.ts
@@ -1,46 +1,15 @@
-//TODO
-
 import { RequestService } from '../RequestService.js';
-import { TicketRequest, TicketRequestStatus, CreateRequestInput, UpdateRequestInput } from '../../types/ticketRequest.js';
-import { IRequestLambdaService } from '../lambda-sdk/interfaces/IRequestLambdaService.js';
-import { requestLambdaServiceMock } from '../lambda-sdk/mocks/RequestLambdaServiceMock.js';
+import {
+    TicketRequest,
+    CreateRequestInput,
+    UpdateRequestInput
+} from '../../types/ticketRequest.js';
+import { requestWriteLambdaServiceAWS } from '../lambda-sdk/services/RequestWriteLambdaServiceAWS.js';
+import {IRequestWriteLambdaService} from "../lambda-sdk/interfaces/IRequestWriteLambdaService.js";
 
 class RequestServiceImplAWSLambda implements RequestService {
-    private lambdaService: IRequestLambdaService = requestLambdaServiceMock;
-
-    async getAllRequests(status?: TicketRequestStatus): Promise<TicketRequest[]> {
-        const lambdaResponse = await this.lambdaService.getAllRequests({
-            action: 'GET_REQUESTS',
-            status: status
-        });
-
-        return lambdaResponse.map(r => ({
-            requestId: r.requestId,
-            requestNumber: r.requestNumber,
-            category: r.category as any,
-            subject: r.subject,
-            userReportedPriority: r.userReportedPriority as any,
-            status: r.status as any,
-            createdAt: r.createdAt
-        }));
-    }
-
-    async getRequestById(requestId: string): Promise<TicketRequest> {
-        const lambdaResponse = await this.lambdaService.getRequestById({
-            action: 'GET_REQUEST',
-            requestId
-        });
-
-        return {
-            requestId: lambdaResponse.requestId,
-            requestNumber: lambdaResponse.requestNumber,
-            category: lambdaResponse.category as any,
-            subject: lambdaResponse.subject,
-            userReportedPriority: lambdaResponse.userReportedPriority as any,
-            status: lambdaResponse.status as any,
-            createdAt: lambdaResponse.createdAt
-        };
-    }
+    private lambdaService: IRequestWriteLambdaService =
+        requestWriteLambdaServiceAWS;
 
     async createRequest(input: CreateRequestInput): Promise<TicketRequest> {
         const lambdaResponse = await this.lambdaService.createRequest({

--- a/backend/gateway/src/services/lambda-sdk/interfaces/IRequestWriteLambdaService.ts
+++ b/backend/gateway/src/services/lambda-sdk/interfaces/IRequestWriteLambdaService.ts
@@ -1,0 +1,11 @@
+import {
+    CreateRequestInputLambda,
+    UpdateRequestInputLambda,
+    RequestLambdaResponse
+} from './IRequestLambdaService.js';
+
+export interface IRequestWriteLambdaService {
+    createRequest(input: CreateRequestInputLambda): Promise<RequestLambdaResponse>;
+    updateRequest(input: UpdateRequestInputLambda): Promise<RequestLambdaResponse>;
+    healthCheck(): Promise<{ service: string; status: string; timestamp: string }>;
+}

--- a/backend/gateway/src/services/lambda-sdk/mocks/RequestLambdaServiceMock.ts
+++ b/backend/gateway/src/services/lambda-sdk/mocks/RequestLambdaServiceMock.ts
@@ -1,98 +1,100 @@
-import { IRequestLambdaService, RequestLambdaResponse, GetRequestsInput, GetRequestByIdInput, CreateRequestInputLambda, UpdateRequestInputLambda } from '../interfaces/IRequestLambdaService.js';
+//TODO delete this mock
 
-export const requestLambdaServiceMock: IRequestLambdaService = {
-    getAllRequests: async (input: GetRequestsInput): Promise<RequestLambdaResponse[]> => {
-        return[
-            {
-                requestId: 'req0',
-                requestNumber: 'REQ-0',
-                userId: 'user_001',
-                userName: 'john_user',
-                userEmail: 'user@test.org',
-                supportId: null,
-                supportName: null,
-                category: 'electrical',
-                subject: 'subject0',
-                userReportedPriority: 'urgent',
-                status: 'new',
-                createdAt: '2025-01-01T10:25:00Z',
-                updatedAt: '2025-01-01T10:25:00Z'
-            },
-            {
-                requestId: 'req1',
-                requestNumber: 'REQ-1',
-                userId: 'support_001',
-                userName: 'name1',
-                userEmail: 'email1@test.org',
-                supportId: null,
-                supportName: null,
-                category: 'plumbing',
-                subject: 'subject1',
-                userReportedPriority: 'low',
-                status: 'rejected',
-                createdAt: '2025-01-01T10:00:00Z',
-                updatedAt: '2025-01-01T10:00:00Z'
-            }
-        ];
-    },
-
-    getRequestById: async (input: GetRequestByIdInput): Promise<RequestLambdaResponse> => {
-        return {
-            requestId: input.requestId,
-            requestNumber: 'REQ-0',
-            userId: 'user0',
-            userName: 'name0',
-            userEmail: 'email0@test.org',
-            supportId: null,
-            supportName: null,
-            category: 'electrical',
-            subject: 'Test request',
-            userReportedPriority: 'high',
-            status: 'new',
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-        };
-    },
-
-    createRequest: async (input: CreateRequestInputLambda): Promise<RequestLambdaResponse> => {
-        return {
-            requestId: 'req-new',
-            requestNumber: 'REQ-NEW',
-            userId: 'user0',
-            userName: 'name0',
-            userEmail: 'email0@test.org',
-            supportId: null,
-            supportName: null,
-            category: input.category,
-            subject: input.subject,
-            userReportedPriority: input.userReportedPriority,
-            status: 'new',
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-        };
-    },
-
-    updateRequest: async (input: UpdateRequestInputLambda): Promise<RequestLambdaResponse> => {
-        return {
-            requestId: input.requestId,
-            requestNumber: 'REQ-UPDATED',
-            userId: 'user0',
-            userName: 'name0',
-            userEmail: 'email0@test.org',
-            supportId: null,
-            supportName: null,
-            category: input.category || 'default',
-            subject: input.subject || 'default',
-            userReportedPriority: input.userReportedPriority || 'medium',
-            status: input.status || 'in_progress',
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-        };
-    },
-
-    healthCheck: async () => ({
-        service: 'request-lambda',
-        status: 'ok',
-        timestamp: new Date().toISOString(),
-    }),
-};
+// import { IRequestLambdaService, RequestLambdaResponse, GetRequestsInput, GetRequestByIdInput, CreateRequestInputLambda, UpdateRequestInputLambda } from '../interfaces/IRequestLambdaService.js';
+//
+// export const requestLambdaServiceMock: IRequestLambdaService = {
+//     getAllRequests: async (input: GetRequestsInput): Promise<RequestLambdaResponse[]> => {
+//         return[
+//             {
+//                 requestId: 'req0',
+//                 requestNumber: 'REQ-0',
+//                 userId: 'user_001',
+//                 userName: 'john_user',
+//                 userEmail: 'user@test.org',
+//                 supportId: null,
+//                 supportName: null,
+//                 category: 'electrical',
+//                 subject: 'subject0',
+//                 userReportedPriority: 'urgent',
+//                 status: 'new',
+//                 createdAt: '2025-01-01T10:25:00Z',
+//                 updatedAt: '2025-01-01T10:25:00Z'
+//             },
+//             {
+//                 requestId: 'req1',
+//                 requestNumber: 'REQ-1',
+//                 userId: 'support_001',
+//                 userName: 'name1',
+//                 userEmail: 'email1@test.org',
+//                 supportId: null,
+//                 supportName: null,
+//                 category: 'plumbing',
+//                 subject: 'subject1',
+//                 userReportedPriority: 'low',
+//                 status: 'rejected',
+//                 createdAt: '2025-01-01T10:00:00Z',
+//                 updatedAt: '2025-01-01T10:00:00Z'
+//             }
+//         ];
+//     },
+//
+//     getRequestById: async (input: GetRequestByIdInput): Promise<RequestLambdaResponse> => {
+//         return {
+//             requestId: input.requestId,
+//             requestNumber: 'REQ-0',
+//             userId: 'user0',
+//             userName: 'name0',
+//             userEmail: 'email0@test.org',
+//             supportId: null,
+//             supportName: null,
+//             category: 'electrical',
+//             subject: 'Test request',
+//             userReportedPriority: 'high',
+//             status: 'new',
+//             createdAt: new Date().toISOString(),
+//             updatedAt: new Date().toISOString(),
+//         };
+//     },
+//
+//     createRequest: async (input: CreateRequestInputLambda): Promise<RequestLambdaResponse> => {
+//         return {
+//             requestId: 'req-new',
+//             requestNumber: 'REQ-NEW',
+//             userId: 'user0',
+//             userName: 'name0',
+//             userEmail: 'email0@test.org',
+//             supportId: null,
+//             supportName: null,
+//             category: input.category,
+//             subject: input.subject,
+//             userReportedPriority: input.userReportedPriority,
+//             status: 'new',
+//             createdAt: new Date().toISOString(),
+//             updatedAt: new Date().toISOString(),
+//         };
+//     },
+//
+//     updateRequest: async (input: UpdateRequestInputLambda): Promise<RequestLambdaResponse> => {
+//         return {
+//             requestId: input.requestId,
+//             requestNumber: 'REQ-UPDATED',
+//             userId: 'user0',
+//             userName: 'name0',
+//             userEmail: 'email0@test.org',
+//             supportId: null,
+//             supportName: null,
+//             category: input.category || 'default',
+//             subject: input.subject || 'default',
+//             userReportedPriority: input.userReportedPriority || 'medium',
+//             status: input.status || 'in_progress',
+//             createdAt: new Date().toISOString(),
+//             updatedAt: new Date().toISOString(),
+//         };
+//     },
+//
+//     healthCheck: async () => ({
+//         service: 'request-lambda',
+//         status: 'ok',
+//         timestamp: new Date().toISOString(),
+//     }),
+// };

--- a/backend/gateway/src/services/lambda-sdk/services/RequestWriteLambdaServiceAWS.ts
+++ b/backend/gateway/src/services/lambda-sdk/services/RequestWriteLambdaServiceAWS.ts
@@ -1,0 +1,42 @@
+import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
+import { IRequestWriteLambdaService } from '../interfaces/IRequestWriteLambdaService.js';
+
+const lambda = new LambdaClient({ region: process.env.AWS_REGION });
+
+class RequestWriteLambdaServiceAWS implements IRequestWriteLambdaService {
+    private functionName = process.env.REQUESTS_LAMBDA_NAME!;
+
+    async createRequest(input: any) {
+        return this.invoke(input);
+    }
+
+    async updateRequest(input: any) {
+        return this.invoke(input);
+    }
+
+    async healthCheck() {
+        return {
+            service: 'requests-lambda',
+            status: 'UP',
+            timestamp: new Date().toISOString()
+        };
+    }
+
+    private async invoke(payload: any) {
+        const command = new InvokeCommand({
+            FunctionName: this.functionName,
+            Payload: Buffer.from(JSON.stringify(payload))
+        });
+
+        const response = await lambda.send(command);
+
+        if (!response.Payload) {
+            throw new Error('Lambda returned empty payload');
+        }
+
+        return JSON.parse(Buffer.from(response.Payload).toString());
+    }
+}
+
+export const requestWriteLambdaServiceAWS =
+    new RequestWriteLambdaServiceAWS();

--- a/backend/gateway/src/utils/request.read.repository.ts
+++ b/backend/gateway/src/utils/request.read.repository.ts
@@ -1,0 +1,67 @@
+import { db } from './db.client.ts';
+import { TicketRequest, TicketRequestStatus } from '../types/ticketRequest.ts';
+
+export async function getAllRequestsFromDB(
+    status?: TicketRequestStatus,
+    user?: { userId: string; role: string }
+): Promise<TicketRequest[]> {
+    let query = `
+    SELECT
+      request_id AS "requestId",
+      request_number AS "requestNumber",
+      category,
+      subject,
+      user_reported_priority AS "userReportedPriority",
+      status,
+      created_at AS "createdAt",
+      created_by AS "userId"
+    FROM requests
+  `;
+
+    const params: any[] = [];
+    const conditions: string[] = [];
+
+    if (user?.role === 'USER') {
+        conditions.push(`created_by = $${params.length + 1}`);
+        params.push(user.userId);
+    }
+
+    if (status) {
+        conditions.push(`status = $${params.length + 1}`);
+        params.push(status);
+    }
+
+    if (conditions.length) {
+        query += ' WHERE ' + conditions.join(' AND ');
+    }
+
+    query += ' ORDER BY created_at DESC';
+
+    const { rows } = await db.query(query, params);
+    return rows;
+}
+
+
+
+export async function getRequestByIdFromDB(
+    requestId: string
+): Promise<TicketRequest | null> {
+    const { rows } = await db.query(
+        `
+    SELECT
+      request_id   AS "requestId",
+      request_number AS "requestNumber",
+      category,
+      subject,
+      user_reported_priority AS "userReportedPriority",
+      status,
+      created_at AS "createdAt",
+      created_by AS "userId"
+    FROM requests
+    WHERE request_id = $1
+    `,
+        [requestId]
+    );
+
+    return rows[0] ?? null;
+}


### PR DESCRIPTION
- Removed read operations from RequestService interface
- Removed getAllRequests / getRequestById from AWS Lambda implementation
- Clarified BFF responsibility as write-side only